### PR TITLE
5 add mixed order method

### DIFF
--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -11,7 +11,7 @@ CFDverify's development process is described here. All regular development to CF
    #. Unit tests: All new code shall have unit tests. The goal of CFDverify is to have 100% coverage, but the precise extent of tests required for new code will be determined on a case-by-case basis.
    #. Regression tests: New methods should add regression tests based on primary literature of the method.
 
-#. Review: Pull requests shall be reviewed by a maintainer. Currently, CFDverify is mainly developed and maintained by a single individual and it is expected he may serve both roles. 
+#. Review: Pull requests shall be reviewed by a maintainer. Currently, CFDverify is mainly developed and maintained by a single individual, so it is expected he may serve both roles. 
 #. Merge: Reviewed and accepted code shall be merged into a development branch of CFDverify.
 #. Deploy: Development branches shall be merged into the main branch of CFDverify following semantic versioning 2.0.0 (see :ref:`semantic-versioning-label`).
 

--- a/docs/source/discretization_error.rst
+++ b/docs/source/discretization_error.rst
@@ -1,7 +1,7 @@
 ErrorModel
 ==========
 
-ErrorModel is the abstract base class for computing the error estimate for a given discretization level. Below is the description of the abstract base calss followed by the concrete classes.
+ErrorModel is the abstract base class for computing the error estimate for a given discretization level. Below is the description of the abstract base class followed by the concrete classes.
 
 .. autoclass:: cfdverify.discretization.ErrorModel
     :members:

--- a/docs/source/discretization_model.rst
+++ b/docs/source/discretization_model.rst
@@ -10,6 +10,10 @@ DiscretizationModel is the abstract base class for discretization error models. 
     :members:
     :show-inheritance:
 
+.. autoclass:: cfdverify.discretization.FirstAndSecondOrder
+    :members:
+    :show-inheritance:
+
 .. autoclass:: cfdverify.discretization.AverageValue
     :members:
     :show-inheritance:

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -3,7 +3,7 @@ Tutorials
 
 .. toctree::
 
-The tutorials sub-directory contains scripts to help new users learn CFDverify. There are currently five tutorial scripts containing quick examples of how to run CFDverify for solution verification analysis. Additionally, the sub-directory contains the same scripts in Jupyter notebook form (.ipynb) if you prefer to conduct your analysis in Jupyter notebooks.
+The tutorials subdirectory contains scripts to help new users learn CFDverify. There are currently five tutorial scripts containing quick examples of how to run CFDverify for solution verification analysis. Additionally, the subdirectory contains the same scripts in Jupyter notebook form (.ipynb) if you prefer to conduct your analysis in Jupyter notebooks.
 
 The tutorials are:
 

--- a/src/cfdverify/discretization.py
+++ b/src/cfdverify/discretization.py
@@ -41,7 +41,7 @@ class DiscretizationModel(ABC):
               key: str,
               h: int | float | np.ndarray
     ) -> int | float | np.ndarray:
-        """Estimate system response quantity at provided discertizations
+        """Estimate system response quantity at provided discretizations
         
         Parameters
         ----------
@@ -94,7 +94,7 @@ class SinglePower(DiscretizationModel):
               key: str,
               h: int | float | np.ndarray
     ) -> int | float | np.ndarray:
-        """Estimate system response quantity at provided discertizations
+        """Estimate system response quantity at provided discretizations
 
         The discretization model for a single term power series expansion is
 
@@ -295,7 +295,7 @@ class AverageValue(DiscretizationModel):
               key: str,
               h: int | float | np.ndarray
     ) -> int | float | np.ndarray:
-        """Estimate system response quantity at provided discertizations
+        """Estimate system response quantity at provided discretizations
 
         AverageValue uses the average of all system response quantities (SRQ)s
         as the estimated true value. This model is useful for cases with 
@@ -358,7 +358,7 @@ class FinestValue(DiscretizationModel):
               key: str,
               h: int | float | np.ndarray
     ) -> int | float | np.ndarray:
-        """Estimate system response quantity at provided discertizations
+        """Estimate system response quantity at provided discretizations
 
         FinestValue uses the system response quantity (SRQ) of the finest 
         result as its estimate. This model is useful if only the finest mesh
@@ -419,7 +419,7 @@ class MaximumValue(DiscretizationModel):
               key: str,
               h: int | float | np.ndarray
     ) -> int | float | np.ndarray:
-        """Estimate system response quantity at provided discertizations
+        """Estimate system response quantity at provided discretizations
 
         MaximumValue uses the largest system response quantity (SRQ) of the 
         results. This model is useful if expert knowledge indicates this is the
@@ -480,7 +480,7 @@ class MinimumValue(DiscretizationModel):
               key: str,
               h: int | float | np.ndarray
     ) -> int | float | np.ndarray:
-        """Estimate system response quantity at provided discertizations
+        """Estimate system response quantity at provided discretizations
 
         MinimumValue uses the smallest system response quantity (SRQ) of the 
         results. This model is useful if expert knowledge indicates this is the
@@ -878,7 +878,7 @@ class DiscretizationError(ABC):
         arg1 : list | tuple | np.ndarray | pd.Series | dict | pd.DataFrame
             Discretization levels (list | tuple) or data (dict | pd.DataFrame)
         arg2 : list | tuple | np.ndarray | pd.Series | dict | str | None
-            System reponse quantities (list | tuple), mesh key (str), or None
+            System response quantities (list | tuple), mesh key (str), or None
         """
         # Create class data from arguments
         self._assign_data(arg1, arg2)
@@ -950,7 +950,7 @@ class DiscretizationError(ABC):
         arg1 : list | tuple | np.ndarray | pd.Series | dict | pd.DataFrame
             Discretization levels (list | tuple) or data (dict | pd.DataFrame)
         arg2 : list | tuple | np.ndarray | pd.Series | dict | str | None
-            System reponse quantities (list | tuple), mesh key (str), or None
+            System response quantities (list | tuple), mesh key (str), or None
         """
         if type(arg1) in [list, tuple, np.ndarray, pd.Series]:
             # Assign mesh sizes based on data type
@@ -1344,7 +1344,7 @@ class CustomDiscretizationError(DiscretizationError):
         arg1 : list | tuple | np.ndarray | pd.Series | dict | pd.DataFrame
             Discretization levels (list | tuple) or data (dict | pd.DataFrame)
         arg2 : list | tuple | np.ndarray | pd.Series | dict | str | None
-            System reponse quantities (list | tuple), mesh key (str), or None
+            System response quantities (list | tuple), mesh key (str), or None
         model : DiscretizationModel
             Discretization model class to use for analysis
         error : ErrorModel

--- a/src/cfdverify/discretization.py
+++ b/src/cfdverify/discretization.py
@@ -210,7 +210,7 @@ class FirstAndSecondOrder(DiscretizationModel):
 
         where :math:`f_h` is the system response quantity (SRQ) at a 
         representative discretization size of :math:`h`, :math:`f_0` is the 
-        estimated SRQ with no discretization error, :math:`\\alpha_1` is the 
+        estimated SRQ for an infinitely fine mesh, :math:`\\alpha_1` is the 
         1st order term coefficient, and :math:`\\alpha_2` is the 2nd order term
         coefficient.
         

--- a/src/cfdverify/discretization.py
+++ b/src/cfdverify/discretization.py
@@ -200,7 +200,7 @@ class FirstAndSecondOrder(DiscretizationModel):
               key: str,
               h: int | float | np.ndarray
     ) -> int | float | np.ndarray:
-        """Estimate system response quantity at provided discertizations
+        """Estimate system response quantity at provided discretizations
 
         The discretization model for a 1st and 2nd order power series expansion
         is
@@ -283,7 +283,7 @@ class FirstAndSecondOrder(DiscretizationModel):
         : pd.Series
             Observed convergence orders
         """
-        return self.parameters.loc[self.parameter_keys[1:]]
+        return pd.Series([1,2])
     
 class AverageValue(DiscretizationModel):
     """Model discretization error as average of all values"""

--- a/src/cfdverify/discretization.py
+++ b/src/cfdverify/discretization.py
@@ -769,8 +769,9 @@ class GCI(UncertaintyModel):
 
         References
         ----------
-        P. J. Roache, "Perspective: A Method for Uniform Reporting of Grid
-        Refinement Studies," Journal of Fluids Engineering, 116:3 (1994).
+        Patrick J. Roache, 1994, Perspective: A Method for Uniform Reporting of
+        Grid Refinement Studies, Journal of Fluids Engineering, 
+        116(3): 405-413. https://doi.org/10.1115/1.2910291.
         """
         gci = fs * self.parent.abs_estimated_error(key, index)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,7 +48,14 @@ def custom(dataframe):
 ## Regression data ############################################################
 @pytest.fixture(scope="package")
 def roy_2003():
-    """Values from Roy 2003 extracted digitally"""
+    """Values from Roy 2003 extracted digitally
+    
+    References
+    ----------
+    Christopher J. Roy, 2003, Grid Convergence Error Analysis for Mixed-Order 
+    Numerical Schemes, AIAA Journal, 41(4): 595-604. 
+    https://doi.org/10.2514/2.2013.
+    """
     hs = [1, 2, 4, 8, 16, 32, 64, 128]
     # Surface pressure at x/R=0.83, Fig. 6
     p8 = [1874.4053654581828,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,9 @@ def custom(dataframe):
 @pytest.fixture(scope="package")
 def roy_2003():
     """Values from Roy 2003 extracted digitally
+
+    Roy's 2003 paper conducts a grid convergence analysis using a mixed-order
+    method and is one of the most complete descriptions of the method.
     
     References
     ----------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,23 +1,30 @@
 from pathlib import Path
-import pytest
+
 import pandas as pd
+import pytest
+
 from cfdverify.discretization import CustomDiscretizationError
+
 
 @pytest.fixture(scope="package")
 def hs() -> list:
     return [0.1, 0.2, 0.5]
 
+
 @pytest.fixture(scope="package")
 def fs() -> list:
     return [9.97, 9.88, 9.25]
+
 
 @pytest.fixture(scope="package")
 def gs() -> list:
     return [10.3, 10.6, 11.5]
 
+
 @pytest.fixture(scope="package")
 def dataframe(hs, fs, gs) -> pd.DataFrame:
     return pd.DataFrame({"hs": hs, "fs": fs, "gs": gs})
+
 
 @pytest.fixture(scope="package")
 def osc_dataframe(hs) -> pd.DataFrame:
@@ -26,11 +33,56 @@ def osc_dataframe(hs) -> pd.DataFrame:
                 "gs": [9.4, 10.4, 10.2]}
     return pd.DataFrame(osc_data)
 
+
 @pytest.fixture(scope="package")
 def least_squared_error_1() -> pd.DataFrame:
     path = Path(__file__).parent.resolve()
     return pd.read_csv(Path(path, "resources", "lse1.csv"))
 
+
 @pytest.fixture(scope="package")
 def custom(dataframe):
     return CustomDiscretizationError(dataframe)
+
+
+## Regression data ############################################################
+@pytest.fixture(scope="package")
+def roy_2003():
+    """Values from Roy 2003 extracted digitally"""
+    hs = [1, 2, 4, 8, 16, 32, 64, 128]
+    # Surface pressure at x/R=0.83, Fig. 6
+    p8 = [1874.4053654581828,
+          1879.7215083533931,
+          1885.0376512486057,
+          1898.3959687363088,
+          1974.5228809387208,
+          2193.893485752481,
+          2730.3208852926946,
+          3931.4490677801496]
+    # Surface pressure at x/R=0.23, Fig. 8
+    p2 = [12979.06819716408,
+          12971.775827143822,
+          12962.052667116814,
+          12945.847400405131,
+          12911.006076975016,
+          12914.247130317352,
+          13302.36326806212,
+          13859.824442943956]
+    # Forebody drag, Fig. 10
+    ds = [0.98892655,
+          0.98830508,
+          0.98734463,
+          0.98553672,
+          0.98293785,
+          0.98062147,
+          1.00757062,
+          1.04683616]
+    # Exact values, from text
+    exact = [1870, 12980, 0.99]
+
+    data = pd.DataFrame({"hs": hs,
+                         "Pressure 0.83": p8,
+                         "Pressure 0.23": p2,
+                         "Drag": ds})
+
+    return data, exact

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -15,8 +15,8 @@ def test_asme_procedure_phi1():
 
     References
     ----------
-    "Procedure for Estimation and Reporting of Uncertainty Due to 
-    Discretization in CFD Applications." ASME. J. Fluids Eng. July 2008; 
+    2008, Procedure for Estimation and Reporting of Uncertainty Due to 
+    Discretization in CFD Applications, Journal of Fluids Engineering, 
     130(7): 078001. https://doi.org/10.1115/1.2960953
     """
     N = [18_000, 8_000, 4_500]
@@ -42,8 +42,8 @@ def test_asme_procedure_phi2():
 
     References
     ----------
-    "Procedure for Estimation and Reporting of Uncertainty Due to 
-    Discretization in CFD Applications." ASME. J. Fluids Eng. July 2008; 
+    2008, Procedure for Estimation and Reporting of Uncertainty Due to 
+    Discretization in CFD Applications, Journal of Fluids Engineering, 
     130(7): 078001. https://doi.org/10.1115/1.2960953
     """
     N = [18_000, 4_500, 980]

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -59,6 +59,7 @@ def test_asme_procedure_phi2():
 
 
 def test_first_and_second_order_literature(roy_2003):
+    """Tests mixed-order method from original work"""
     roy_data = roy_2003[0]
     roy_exact = roy_2003[1]
     model = dis.CustomDiscretizationError(roy_data, model=dis.FirstAndSecondOrder)

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1,6 +1,8 @@
 from pytest import approx
+
 import cfdverify.utils as utils
-from cfdverify.discretization import Classic
+import cfdverify.discretization as dis
+
 
 def test_asme_procedure_phi1():
     """Test against ASME JFE annoucement
@@ -21,12 +23,13 @@ def test_asme_procedure_phi1():
     V = 1 # placeholder volume
     mesh_sizes = utils.mesh_size(V, N, 2)
     phi1 = [6.063, 5.972, 5.863]
-    model = Classic(mesh_sizes, phi1)
+    model = dis.Classic(mesh_sizes, phi1)
     assert model.refinement_ratios == approx([1.5, 1.333], abs=0.0005)
     assert model.order["System Response Quantity"] == approx(1.53, abs=0.005)
     assert model.f_est["System Response Quantity"] == approx(6.1685,
                                                              abs=0.00005)
     assert model.uncertainty("System Response Quantity", 0, normalize=True) == approx(0.022, abs=0.0005)
+
 
 def test_asme_procedure_phi2():
     """Test against ASME JFE annoucement
@@ -47,9 +50,17 @@ def test_asme_procedure_phi2():
     V = 1 # placeholder volume
     mesh_sizes = utils.mesh_size(V, N, 2)
     phi1 = [10.7880, 10.7250, 10.6050]
-    model = Classic(mesh_sizes, phi1)
+    model = dis.Classic(mesh_sizes, phi1)
     assert model.refinement_ratios == approx([2.0, 2.143], abs=0.0005)
     assert model.order["System Response Quantity"] == approx(0.75, abs=0.005)
     assert model.f_est["System Response Quantity"] == approx(10.8801,
                                                              abs=0.00005)
     assert model.uncertainty("System Response Quantity", 0, normalize=True) == approx(0.011, abs=0.0005)
+
+
+def test_first_and_second_order_literature(roy_2003):
+    roy_data = roy_2003[0]
+    roy_exact = roy_2003[1]
+    model = dis.CustomDiscretizationError(roy_data, model=dis.FirstAndSecondOrder)
+
+    assert model.f_est.values == approx(roy_exact, rel=0.05)

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -5,13 +5,13 @@ import cfdverify.discretization as dis
 
 
 def test_asme_procedure_phi1():
-    """Test against ASME JFE annoucement
+    """Test against ASME JFE announcement
     
     This test tests the code against the data contained in the American Society
-    of Mechanical Engineer's Journal of Fluids Engineering annoucement 
+    of Mechanical Engineer's Journal of Fluids Engineering announcement
     "Procedure for Estimation and Reporting of Uncertainty Due to 
     Discretization in CFD Applications." Specifically, this test compares data 
-    for the first response quantity, the dimensionless reattachement length.
+    for the first response quantity, the dimensionless reattachment length.
 
     References
     ----------
@@ -32,10 +32,10 @@ def test_asme_procedure_phi1():
 
 
 def test_asme_procedure_phi2():
-    """Test against ASME JFE annoucement
+    """Test against ASME JFE announcement
     
     This test tests the code against the data contained in the American Society
-    of Mechanical Engineer's Journal of Fluids Engineering annoucement 
+    of Mechanical Engineer's Journal of Fluids Engineering announcement
     "Procedure for Estimation and Reporting of Uncertainty Due to 
     Discretization in CFD Applications." Specifically, this test compares data 
     for the second response quantity, the axial velocity at x/H=8 and y=0.0526.

--- a/tests/test_unit_discretization.py
+++ b/tests/test_unit_discretization.py
@@ -185,9 +185,9 @@ def test_average(dataframe):
 def test_singlepower(dataframe):
     """Test SinglePower class"""
     model = dis.CustomDiscretizationError(dataframe, model=dis.SinglePower)
-    test_data = pd.DataFrame({"fs": [10.0, 2.0, -3.0],
-                              "gs": [10.0, 1.0, 3.0]},
-                             index=["f_est", "p", "alpha"])
+    test_data = pd.DataFrame({"fs": [10.0, -3.0, 2.0],
+                              "gs": [10.0, 3.0, 1.0]},
+                             index=["f_est", "alpha", "p"])
     assert model.model.parameter_keys == list(test_data.index)
     pd.testing.assert_frame_equal(model.model.parameters, test_data,
                                   check_dtype=False)
@@ -200,6 +200,9 @@ def test_singlepower(dataframe):
     assert model.model("fs", 0) == approx(10)
     assert model.model("fs", np.array([0, 0.5])) == approx([10, 9.25])
 
+def test_first_and_second_order(dataframe):
+    """Test SinglePower class"""
+    assert False
 
 def test_averagevalue(dataframe):
     """Test AverageValue class"""

--- a/tests/test_unit_discretization.py
+++ b/tests/test_unit_discretization.py
@@ -201,8 +201,22 @@ def test_singlepower(dataframe):
     assert model.model("fs", np.array([0, 0.5])) == approx([10, 9.25])
 
 def test_first_and_second_order(dataframe):
-    """Test SinglePower class"""
-    assert False
+    """Test FirstAndSecondOrder class"""
+    model = dis.CustomDiscretizationError(dataframe, model=dis.FirstAndSecondOrder)
+    test_data = pd.DataFrame({"fs": [10.0, 0.0, -3.0],
+                              "gs": [10.0, 3.0, 0.0]},
+                             index=["f_est", "alpha_1", "alpha_2"])
+    assert model.model.parameter_keys == list(test_data.index)
+    pd.testing.assert_frame_equal(model.model.parameters, test_data,
+                                  check_dtype=False, atol=1e-6)
+    pd.testing.assert_series_equal(model.f_est, test_data.loc["f_est"],
+                                   check_dtype=False,
+                                   check_index=False)
+    pd.testing.assert_series_equal(model.order, pd.Series([1,2]),
+                                   check_dtype=False,
+                                   check_index=False)
+    assert model.model("fs", 0) == approx(10)
+    assert model.model("fs", np.array([0, 0.5])) == approx([10, 9.25])
 
 def test_averagevalue(dataframe):
     """Test AverageValue class"""

--- a/tutorials/tutorial_4.py
+++ b/tutorials/tutorial_4.py
@@ -31,7 +31,7 @@ print(f"Number of meshes: {len(model)}")
 # Get the relative error of simulation responses
 print(f"Relative error of DP: \n{model.relative_error('Vel')}")
 # Or you can get the absolute relative error
-print(f"Asbsolute relative error of DP: \n{model.abs_relative_error('Vel')}")
+print(f"Absolute relative error of DP: \n{model.abs_relative_error('Vel')}")
 
 # %%
 ## Data interpretation


### PR DESCRIPTION
This pull request adds a mixed order, specifically a 1st and 2nd order method as it is the only commonly used method in literature. It adds:

- The `FirstAndSecondOrder` DiscretizationModel class
- Unit test
- Regression test using data from Roy 2003

It follows the development process outlined here: https://cfd-verify.readthedocs.io/en/latest/development.html