### PR TITLE
10 add ipykernel to dependencies for jupyter notebooks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ If you prefer to install from the `source <https://github.com/ORNL/cfd-verify>`_
     source /path/to/your/venv/bin/activate
     pip install .
 
-To install dependencies for testing the code, install with the command :code:`pip install .[tests]`. Likewise, to install documentation dependencies use the command :code:`pip install .[docs]`. Alternatively, install all optional dependencies using the command :code:`pip install .[full]`.
+To install dependencies for testing the code, install with the command :code:`pip install .[tests]`. Likewise, to install documentation dependencies use the command :code:`pip install .[docs]`. Alternatively, install all optional dependencies using the command :code:`pip install .[full]`. The full installation includes additional helpful modules that a user will likely need for scientific computing workflow in the `utilities` optional dependency lists (e.g. `ipykernel` for running interactive Jupyter notebooks). Users new to scientific computing are recommended to use the full install.
 
 Documentation
 -------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ docs = [
   "sphinx",
   "sphinx-rtd-theme",
 ]
+utilities = [
+  "ipykernel",
+]
 full = [
-    "cfdverify[tests, docs]",
+    "cfdverify[tests, docs, utilities]",
 ]


### PR DESCRIPTION
Adds the utilities optional dependency list to help install optional packages for users new to scientific computing so they have all utilities used in tutorials. 